### PR TITLE
Add chinese comments to prompt

### DIFF
--- a/backend/agent/prompt.py
+++ b/backend/agent/prompt.py
@@ -1,7 +1,7 @@
-import datetime  # 导入 datetime 模块，用于获取当前的日期和时间
+import datetime  # 导入 Python 的 datetime 模块，用于获取当前的日期和时间
 
-# 定义系统提示词，其中会动态插入当前 UTC 日期和时间
-SYSTEM_PROMPT = f"""
+# 定义系统提示词常量，会动态插入当前 UTC 日期和时间
+SYSTEM_PROMPT = f"""  # 使用 f-string 在运行时插入日期和时间
 You are Suna.so, an autonomous AI Agent created by the Kortix team.
 
 # 1. CORE IDENTITY & CAPABILITIES
@@ -620,9 +620,9 @@ For casual conversation and social interactions:
   * The system will continue running in a loop if completion is not signaled
   * Additional commands after completion are considered errors
   * Redundant verifications after completion are prohibited
-  """
+  """  # 系统提示词定义结束
 
 
-def get_system_prompt():
+def get_system_prompt():  # 定义一个函数，用于获取系统提示词
     """返回上面定义的系统提示词"""
     return SYSTEM_PROMPT  # 直接返回 SYSTEM_PROMPT 字符串

--- a/backend/agent/prompt.py
+++ b/backend/agent/prompt.py
@@ -1,5 +1,6 @@
-import datetime
+import datetime  # 导入 datetime 模块，用于获取当前的日期和时间
 
+# 定义系统提示词，其中会动态插入当前 UTC 日期和时间
 SYSTEM_PROMPT = f"""
 You are Suna.so, an autonomous AI Agent created by the Kortix team.
 
@@ -623,7 +624,5 @@ For casual conversation and social interactions:
 
 
 def get_system_prompt():
-    '''
-    Returns the system prompt
-    '''
-    return SYSTEM_PROMPT 
+    """返回上面定义的系统提示词"""
+    return SYSTEM_PROMPT  # 直接返回 SYSTEM_PROMPT 字符串


### PR DESCRIPTION
## Summary
- add chinese comments for `import datetime` and system prompt definition
- document get_system_prompt function in Chinese

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864eee311ac832f8e53d3c5188e3471